### PR TITLE
Fix session persistence with filesystem-backed Flask sessions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,7 @@ import json
 import os
 from logging.config import dictConfig
 from flask import Flask, flash
+from flask_session import Session
 from werkzeug.middleware.proxy_fix import ProxyFix
 from app.deployments.routes import deployments_bp
 from app.errors.routes import errors_bp
@@ -68,6 +69,12 @@ def create_app(aligndb=True):
     
     # Mitigates CSRF attacks
     app.config["SESSION_COOKIE_SAMESITE"] = "Lax"  
+
+    # Fix Session not in cookie
+    app.config["SESSION_TYPE"] = "filesystem"
+    app.config["SESSION_PERMANENT"] = False
+    app.config["SESSION_USE_SIGNER"] = True
+    app.config["SESSION_FILE_DIR"] = "./.flask_session"
 
     # load hierarchical configuration
 
@@ -169,6 +176,7 @@ def create_app(aligndb=True):
 
     register_blueprints(app)
 
+    Session(app)
     return app
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Caching==2.1.0
 Flask_Dance==7.0.1
 Flask-Mail==0.9.1
 Flask-Redis==0.4.0
+Flask_Session==0.8.0
 PyYAML
 python-dateutil
 python-Levenshtein==0.27.1


### PR DESCRIPTION
This PR changes session management to use Flask-Session with filesystem-backed storage:

- Configure server-side sessions with `SESSION_TYPE=filesystem`
- Disable permanent sessions
- Store session files under `./.flask_session`
- Initialize `Flask-Session` in the app factory
- Add `Flask_Session==0.8.0` to requirements

This fixes issues caused by storing session data in cookies.